### PR TITLE
Implement IAsyncEnumerable Stream Processing

### DIFF
--- a/FastMediator/Behaviors/StreamValidationBehavior.cs
+++ b/FastMediator/Behaviors/StreamValidationBehavior.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FastMediator.Configuration;
+using FastMediator.Interfaces;
+using FastMediator.Logging;
+using FastMediator.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace FastMediator.Behaviors
+{
+    /// <summary>
+    /// Behavior che esegue la validazione delle richieste stream
+    /// </summary>
+    /// <typeparam name="TRequest">Il tipo di richiesta</typeparam>
+    /// <typeparam name="TResponse">Il tipo di risposta</typeparam>
+    public class StreamValidationBehavior<TRequest, TResponse> : IStreamPipelineBehavior<TRequest, TResponse>, IOrderedPipelineBehavior
+        where TRequest : IStreamRequest<TResponse>
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<StreamValidationBehavior<TRequest, TResponse>> _logger;
+        private readonly FastMediatorOptions _options;
+
+        /// <summary>
+        /// Inizializza una nuova istanza del behavior di validazione per gli stream
+        /// </summary>
+        public StreamValidationBehavior(IServiceProvider serviceProvider, FastMediatorOptions options)
+        {
+            _serviceProvider = serviceProvider;
+            _options = options;
+            _logger = MediatorLoggerFactory.CreateLogger<StreamValidationBehavior<TRequest, TResponse>>(options);
+        }
+
+        /// <summary>
+        /// Ordine di esecuzione del behavior (più basso = priorità maggiore)
+        /// </summary>
+        public int Order => -10; // Esegui prima degli altri behavior
+
+        /// <summary>
+        /// Gestisce la richiesta stream eseguendo la validazione prima di procedere
+        /// </summary>
+        public async IAsyncEnumerable<TResponse> HandleStream(TRequest request, Func<TRequest, CancellationToken, IAsyncEnumerable<TResponse>> next, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            // Ottieni tutti i validatori per questo tipo di richiesta
+            var validators = _serviceProvider.GetServices<IValidator<TRequest>>().ToList();
+
+            if (validators.Any())
+            {
+                _logger.LogDebug("Trovati {ValidatorCount} validatori per la richiesta stream {RequestType}",
+                    validators.Count, typeof(TRequest).Name);
+
+                // Esegui tutti i validatori e raccogli gli errori (non supportiamo validatori asincroni nel framework base per ora)
+                var validationResults = new List<ValidationResult>();
+                foreach (var validator in validators)
+                {
+                    var result = validator.Validate(request);
+                    validationResults.Add(result);
+                }
+
+                // Verifica se ci sono errori di validazione
+                var errors = validationResults
+                    .SelectMany(r => r.Errors)
+                    .Where(e => e != null)
+                    .ToList();
+
+                if (errors.Any())
+                {
+                    _logger.LogWarning("Validazione fallita per la richiesta stream {RequestType}. Errori: {ErrorCount}",
+                        typeof(TRequest).Name, errors.Count);
+
+                    throw new ValidationException(errors);
+                }
+            }
+
+            // La validazione è passata, procedi con la pipeline
+            var stream = next(request, cancellationToken);
+            await foreach(var item in stream.WithCancellation(cancellationToken))
+            {
+                yield return item;
+            }
+        }
+    }
+}

--- a/FastMediator/Caching/DelegateCache.cs
+++ b/FastMediator/Caching/DelegateCache.cs
@@ -24,6 +24,8 @@ namespace FastMediator.Caching
         // Cache per i delegati degli handler asincroni delle notifiche
         private readonly ConcurrentDictionary<Type, Func<IServiceProvider, object, CancellationToken, Task>> _asyncNotificationHandlerCache = new();
 
+        // Cache per i delegati degli stream handler
+        private readonly ConcurrentDictionary<RequestCacheKey, Func<IServiceProvider, object, CancellationToken, object>> _streamRequestHandlerCache = new();
 
         // Statistiche della cache per diagnostica
         private int _requestHits;
@@ -34,6 +36,8 @@ namespace FastMediator.Caching
         private int _asyncRequestMisses;
         private int _asyncNotificationHits;
         private int _asyncNotificationMisses;
+        private int _streamRequestHits;
+        private int _streamRequestMisses;
 
         // Singleton
         public static DelegateCache Instance => _instance.Value;
@@ -195,8 +199,36 @@ namespace FastMediator.Caching
             return handler;
         }
 
+        /// <summary>
+        /// Statistiche di utilizzo della cache degli stream handler
+        /// </summary>
+        public (int Hits, int Misses) StreamRequestStats => (_streamRequestHits, _streamRequestMisses);
 
+        /// <summary>
+        /// Dimensione della cache degli stream handler
+        /// </summary>
+        public int StreamRequestHandlerCacheSize => _streamRequestHandlerCache.Count;
 
+        /// <summary>
+        /// Ottiene un delegato esistente o ne crea uno nuovo per uno stream handler
+        /// </summary>
+        public Func<IServiceProvider, object, CancellationToken, object> GetOrCreateStreamRequestHandler<TRequest, TResponse>(
+            Func<Func<IServiceProvider, object, CancellationToken, object>> factory)
+            where TRequest : IStreamRequest<TResponse>
+        {
+            var key = new RequestCacheKey(typeof(TRequest), typeof(TResponse));
+
+            if (_streamRequestHandlerCache.TryGetValue(key, out var cachedHandler))
+            {
+                Interlocked.Increment(ref _streamRequestHits);
+                return cachedHandler;
+            }
+
+            Interlocked.Increment(ref _streamRequestMisses);
+            var handler = factory();
+            _streamRequestHandlerCache[key] = handler;
+            return handler;
+        }
 
         /// <summary>
         /// Svuota la cache e azzera le statistiche
@@ -215,6 +247,9 @@ namespace FastMediator.Caching
             _asyncRequestMisses = 0;
             _asyncNotificationHits = 0;
             _asyncNotificationMisses = 0;
+            _streamRequestHandlerCache.Clear();
+            _streamRequestHits = 0;
+            _streamRequestMisses = 0;
         }
     }
 }

--- a/FastMediator/Core/Dispatcher.cs
+++ b/FastMediator/Core/Dispatcher.cs
@@ -27,6 +27,9 @@ namespace FastMediator.Core
         private readonly Dictionary<Type, List<Func<IServiceProvider, object, CancellationToken, Task>>> _asyncNotificationHandlers = new();
         private readonly ConcurrentDictionary<Type, object> _asyncHandlerFactories;
 
+        private readonly Dictionary<Type, Func<IServiceProvider, object, CancellationToken, object>> _streamHandlers = new();
+        private readonly ConcurrentDictionary<Type, object> _streamHandlerFactories;
+
         /// <summary>
         /// Crea una nuova istanza del dispatcher
         /// </summary>
@@ -35,10 +38,12 @@ namespace FastMediator.Core
                            Dictionary<Type, List<Action<IServiceProvider, object>>> notificationHandlers,
                            Dictionary<Type, Func<IServiceProvider, object, CancellationToken, Task<object>>> asyncHandlers,
                            Dictionary<Type, List<Func<IServiceProvider, object, CancellationToken, Task>>> asyncNotificationHandlers,
+                           Dictionary<Type, Func<IServiceProvider, object, CancellationToken, object>> streamHandlers,
                            FastMediatorOptions options) 
         {
             _asyncHandlers = asyncHandlers;
             _asyncNotificationHandlers = asyncNotificationHandlers;
+            _streamHandlers = streamHandlers ?? new Dictionary<Type, Func<IServiceProvider, object, CancellationToken, object>>();
 
             _provider = provider;
             _handlers = handlers;
@@ -50,6 +55,7 @@ namespace FastMediator.Core
             {
                 _handlerFactories = new ConcurrentDictionary<Type, object>();
                 _asyncHandlerFactories = new ConcurrentDictionary<Type, object>();
+                _streamHandlerFactories = new ConcurrentDictionary<Type, object>();
             }
         }
 
@@ -173,6 +179,47 @@ namespace FastMediator.Core
             }
         }
 
+        /// <summary>
+        /// Crea uno stream di risposte da una richiesta stream
+        /// </summary>
+        /// <typeparam name="TResponse">Il tipo di risposta atteso nello stream</typeparam>
+        /// <param name="request">La richiesta stream da inviare</param>
+        /// <param name="cancellationToken">Token per la cancellazione dell'operazione</param>
+        /// <returns>Uno stream IAsyncEnumerable di risposte</returns>
+        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
+        {
+            var type = request.GetType();
+
+            // Approccio standard
+            if (_options.RegistrationMode == HandlerRegistrationMode.Startup || _streamHandlers.ContainsKey(type))
+            {
+                if (!_streamHandlers.TryGetValue(type, out var handlerStd))
+                    throw new InvalidOperationException($"Stream handler not found for request type {type.Name}");
+
+                return (IAsyncEnumerable<TResponse>)handlerStd(_provider, request, cancellationToken);
+            }
+
+            // Approccio dinamico (lazy loading o ibrido per tipi non pre-registrati)
+            var responseType = typeof(TResponse);
+            var handler = GetOrCreateStreamHandler(type, responseType);
+            return (IAsyncEnumerable<TResponse>)handler(_provider, request, cancellationToken);
+        }
+
+        // Nuovo metodo per lazy loading degli stream handler
+        private Func<IServiceProvider, object, CancellationToken, object> GetOrCreateStreamHandler(Type requestType, Type responseType)
+        {
+            return _streamHandlerFactories.GetOrAdd(requestType, _ => {
+                // Crea il tipo della factory
+                var factoryType = typeof(StreamRequestHandlerFactory<,>).MakeGenericType(requestType, responseType);
+
+                // Chiama il metodo statico CreateHandler
+                var createMethod = factoryType.GetMethod("CreateHandler", BindingFlags.Public | BindingFlags.Static);
+                var handlerDelegate = (Func<IServiceProvider, object, CancellationToken, object>)createMethod.Invoke(null, null);
+
+                return handlerDelegate;
+            }) as Func<IServiceProvider, object, CancellationToken, object>;
+        }
+
         // Nuovo metodo per lazy loading degli handler asincroni
         private Func<IServiceProvider, object, CancellationToken, Task<object>> GetOrCreateAsyncHandler(Type requestType, Type responseType)
         {
@@ -234,6 +281,15 @@ namespace FastMediator.Core
         /// </summary>
         public int AsyncNotificationHandlerCacheSize => DelegateCache.Instance.AsyncNotificationHandlerCacheSize;
 
+        /// <summary>
+        /// Ottiene le statistiche di utilizzo della cache degli stream handler
+        /// </summary>
+        public (int Hits, int Misses) GetStreamRequestHandlerCacheStats() => DelegateCache.Instance.StreamRequestStats;
+
+        /// <summary>
+        /// Ottiene la dimensione della cache degli stream handler
+        /// </summary>
+        public int StreamRequestHandlerCacheSize => DelegateCache.Instance.StreamRequestHandlerCacheSize;
 
     }
 }

--- a/FastMediator/Core/DispatcherAsyncExtensions.cs
+++ b/FastMediator/Core/DispatcherAsyncExtensions.cs
@@ -36,5 +36,14 @@ namespace FastMediator.Core
         {
             return dispatcher.PublishAsyncSequential(notification, cancellationToken);
         }
+
+        /// <summary>
+        /// Crea uno stream da una richiesta asincrona
+        /// </summary>
+        public static System.Collections.Generic.IAsyncEnumerable<TResponse> CreateStream<TRequest, TResponse>(this Dispatcher dispatcher, TRequest request, CancellationToken cancellationToken = default)
+            where TRequest : IStreamRequest<TResponse>
+        {
+            return dispatcher.CreateStream<TResponse>(request, cancellationToken);
+        }
     }
 }

--- a/FastMediator/DependencyInjection/AsyncRequestHandlerFactory.cs
+++ b/FastMediator/DependencyInjection/AsyncRequestHandlerFactory.cs
@@ -42,7 +42,7 @@ namespace FastMediator.DependencyInjection
                                      Behavior = b,
                                      Order = (b as IOrderedPipelineBehavior)?.Order ?? int.MaxValue
                                  })
-                                 .OrderBy(x => x.Order)
+                                 .OrderByDescending(x => x.Order)
                                  .Select(x => x.Behavior);
 
                         // Costruisci la pipeline in ordine inverso

--- a/FastMediator/DependencyInjection/RequestHandlerFactory.cs
+++ b/FastMediator/DependencyInjection/RequestHandlerFactory.cs
@@ -40,7 +40,7 @@ namespace FastMediator.DependencyInjection
                                      Behavior = b,
                                      Order = (b as IOrderedPipelineBehavior)?.Order ?? int.MaxValue
                                  })
-                                 .OrderBy(x => x.Order)
+                                 .OrderByDescending(x => x.Order)
                                  .Select(x => x.Behavior);
 
                         // Costruisci la pipeline in ordine inverso

--- a/FastMediator/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/FastMediator/DependencyInjection/ServiceCollectionExtensions.cs
@@ -117,11 +117,18 @@ namespace FastMediator.DependencyInjection
                    .WithTransientLifetime()
                    .AddClasses(classes => classes.AssignableTo(typeof(IPipelineBehaviorAsync<,>)))
                    .AsImplementedInterfaces()
+                   .WithTransientLifetime()
+                   .AddClasses(classes => classes.AssignableTo(typeof(IStreamRequestHandler<,>)))
+                   .AsImplementedInterfaces()
+                   .WithTransientLifetime()
+                   .AddClasses(classes => classes.AssignableTo(typeof(IStreamPipelineBehavior<,>)))
+                   .AsImplementedInterfaces()
                    .WithTransientLifetime();
             });
 
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
             services.AddTransient(typeof(IPipelineBehaviorAsync<,>), typeof(ValidationBehaviorAsync<,>));
+            services.AddTransient(typeof(IStreamPipelineBehavior<,>), typeof(StreamValidationBehavior<,>));
 
             services.AddSingleton<Dispatcher>(sp =>
             {
@@ -129,6 +136,7 @@ namespace FastMediator.DependencyInjection
                 var notificationMap = new Dictionary<Type, List<Action<IServiceProvider, object>>>();
                 var asyncHandlerMap = new Dictionary<Type, Func<IServiceProvider, object, CancellationToken, Task<object>>>();
                 var asyncNotificationMap = new Dictionary<Type, List<Func<IServiceProvider, object, CancellationToken, Task>>>();
+                var streamHandlerMap = new Dictionary<Type, Func<IServiceProvider, object, CancellationToken, object>>();
 
                 if (options.RegistrationMode == HandlerRegistrationMode.Startup ||
                     options.RegistrationMode == HandlerRegistrationMode.Hybrid)
@@ -180,6 +188,28 @@ namespace FastMediator.DependencyInjection
                         asyncHandlerMap[requestType] = handlerDelegate;
                     }
 
+                    // Aggiungiamo gli stream handler
+                    var streamRequestHandlerTypes = services
+                        .Where(sd => sd.ServiceType.IsGenericType &&
+                                     sd.ServiceType.GetGenericTypeDefinition() == typeof(IStreamRequestHandler<,>))
+                        .ToList();
+
+                    foreach (var descriptor in streamRequestHandlerTypes)
+                    {
+                        var serviceType = descriptor.ServiceType;
+                        var requestType = serviceType.GenericTypeArguments[0];
+                        var responseType = serviceType.GenericTypeArguments[1];
+
+                        // Creiamo il tipo della factory
+                        var factoryType = typeof(StreamRequestHandlerFactory<,>).MakeGenericType(requestType, responseType);
+
+                        // Chiamiamo il metodo statico CreateHandler
+                        var createMethod = factoryType.GetMethod("CreateHandler", BindingFlags.Public | BindingFlags.Static);
+                        var handlerDelegate = (Func<IServiceProvider, object, CancellationToken, object>)createMethod.Invoke(null, null);
+
+                        // Aggiungiamo il delegato alla mappa
+                        streamHandlerMap[requestType] = handlerDelegate;
+                    }
                 }
 
                 // Ottieni tutti i tipi di handler di notifiche registrati
@@ -232,7 +262,7 @@ namespace FastMediator.DependencyInjection
                     asyncNotificationMap[notificationType].Add(handlerFunc);
                 }
 
-                return new Dispatcher(sp, handlerMap, notificationMap, asyncHandlerMap, asyncNotificationMap, options);
+                return new Dispatcher(sp, handlerMap, notificationMap, asyncHandlerMap, asyncNotificationMap, streamHandlerMap, options);
             });
 
             return services;

--- a/FastMediator/DependencyInjection/StreamRequestHandlerFactory.cs
+++ b/FastMediator/DependencyInjection/StreamRequestHandlerFactory.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FastMediator.Caching;
+using FastMediator.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FastMediator.DependencyInjection
+{
+    // Classe helper tipizzata per ogni combinazione di tipi di stream request/response
+    public class StreamRequestHandlerFactory<TRequest, TResponse>
+        where TRequest : IStreamRequest<TResponse>
+    {
+        // Metodo statico che crea il delegato per l'handler stream
+        public static Func<IServiceProvider, object, CancellationToken, object> CreateHandler()
+        {
+            // Utilizziamo DelegateCache per memorizzare il delegato
+            return DelegateCache.Instance.GetOrCreateStreamRequestHandler<TRequest, TResponse>(() =>
+            {
+                return (provider, request, cancellationToken) =>
+                {
+                    return HandleStream(provider, (TRequest)request, cancellationToken);
+                };
+            });
+        }
+
+        private static async IAsyncEnumerable<TResponse> HandleStream(IServiceProvider provider, TRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            // Ottieni il factory per creare un nuovo scope che durerà per tutto il ciclo di vita dell'enumeratore
+            var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+            // Crea un nuovo scope per l'esecuzione dello stream
+            using (var scope = scopeFactory.CreateScope())
+            {
+                // Usa il provider dello scope per risolvere l'handler
+                var handler = scope.ServiceProvider.GetRequiredService<IStreamRequestHandler<TRequest, TResponse>>();
+
+                // E i behaviors dello stream
+                var behaviors = scope.ServiceProvider.GetServices<IStreamPipelineBehavior<TRequest, TResponse>>();
+
+                // Crea la funzione di base che invoca l'handler
+                Func<TRequest, CancellationToken, IAsyncEnumerable<TResponse>> pipeline = (req, token) =>
+                    handler.HandleStream(req, token);
+
+                var orderedBehaviors = behaviors
+                         .Select(b => new
+                         {
+                             Behavior = b,
+                             Order = (b as IOrderedPipelineBehavior)?.Order ?? int.MaxValue
+                         })
+                         .OrderByDescending(x => x.Order)
+                         .Select(x => x.Behavior);
+
+                // Costruisci la pipeline in ordine inverso
+                foreach (var behavior in orderedBehaviors)
+                {
+                    var currentPipeline = pipeline;
+                    pipeline = (req, token) => behavior.HandleStream(req, currentPipeline, token);
+                }
+
+                // Esegui la pipeline e yielda i risultati, preservando il ciclo di vita dello scope
+                var enumerable = pipeline(request, cancellationToken);
+                await foreach (var item in enumerable.WithCancellation(cancellationToken))
+                {
+                    yield return item;
+                }
+            }
+        }
+    }
+}

--- a/FastMediator/Interfaces/IStreamPipelineBehavior.cs
+++ b/FastMediator/Interfaces/IStreamPipelineBehavior.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace FastMediator.Interfaces
+{
+    /// <summary>
+    /// Definisce un comportamento della pipeline per l'elaborazione di stream asincroni
+    /// </summary>
+    /// <typeparam name="TRequest">Il tipo di richiesta gestita</typeparam>
+    /// <typeparam name="TResponse">Il tipo di risposta prodotta nello stream</typeparam>
+    public interface IStreamPipelineBehavior<TRequest, TResponse>
+        where TRequest : IStreamRequest<TResponse>
+    {
+        /// <summary>
+        /// Gestisce la richiesta stream e chiama il successivo gestore nella pipeline
+        /// </summary>
+        /// <param name="request">La richiesta da gestire</param>
+        /// <param name="next">Il delegato che rappresenta il successivo elemento della pipeline, che restituisce l'IAsyncEnumerable originale</param>
+        /// <param name="cancellationToken">Token per la cancellazione dell'operazione</param>
+        /// <returns>Il flusso IAsyncEnumerable risultante (potenzialmente modificato o intercettato)</returns>
+        IAsyncEnumerable<TResponse> HandleStream(TRequest request, Func<TRequest, CancellationToken, IAsyncEnumerable<TResponse>> next, CancellationToken cancellationToken = default);
+    }
+}

--- a/FastMediator/Interfaces/IStreamRequest.cs
+++ b/FastMediator/Interfaces/IStreamRequest.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace FastMediator.Interfaces
+{
+    /// <summary>
+    /// Rappresenta una richiesta che produrrà un flusso asincrono di risposte di tipo TResponse
+    /// </summary>
+    /// <typeparam name="TResponse">Il tipo di risposta prodotta nello stream</typeparam>
+    public interface IStreamRequest<TResponse> { }
+}

--- a/FastMediator/Interfaces/IStreamRequestHandler.cs
+++ b/FastMediator/Interfaces/IStreamRequestHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace FastMediator.Interfaces
+{
+    /// <summary>
+    /// Gestisce una richiesta asincrona sotto forma di stream (IAsyncEnumerable)
+    /// </summary>
+    /// <typeparam name="TRequest">Il tipo di richiesta da gestire</typeparam>
+    /// <typeparam name="TResponse">Il tipo di risposta da produrre nello stream</typeparam>
+    public interface IStreamRequestHandler<TRequest, TResponse>
+        where TRequest : IStreamRequest<TResponse>
+    {
+        /// <summary>
+        /// Gestisce la richiesta restituendo uno stream asincrono di risposte
+        /// </summary>
+        /// <param name="request">La richiesta da gestire</param>
+        /// <param name="cancellationToken">Token per la cancellazione dell'operazione</param>
+        /// <returns>Un IAsyncEnumerable di risposte</returns>
+        IAsyncEnumerable<TResponse> HandleStream(TRequest request, CancellationToken cancellationToken = default);
+    }
+}


### PR DESCRIPTION
This change introduces stream processing using `IAsyncEnumerable` across the `FastMediator` pattern to handle multiple items asynchronously emitted by request handlers. It fixes existing pipeline ordering bugs by correctly implementing the `OrderByDescending` traversal requirement and avoids dictionary multi-threading vulnerabilities in the `Dispatcher`'s lazy loading code logic.

---
*PR created automatically by Jules for task [1679469730785349397](https://jules.google.com/task/1679469730785349397) started by @DDT88*